### PR TITLE
Pass reqExp option to interpolateName method

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports.pitch = function(remainingRequest) {
 	if(query.name) {
 		var options = {
 			context: query.context || this.options.context,
+			regExp: query.regExp
 		};
 		var chunkName = loaderUtils.interpolateName(this, query.name, options);
 		var chunkNameParam = ", " + JSON.stringify(chunkName);		


### PR DESCRIPTION
Add ability to generate dynamic bundle name according to required file path

Example:

```javascript
module: {
  loaders: [
    { 
      test: /bundle\.js$/, 
      loader: 'bundle',
      query: { 
        lazy: true, 
        name: "[1]",
        regExp: "([\\w\\.]+)\\/[\\w\\.]+$"
      }
    }
  ]
}
```